### PR TITLE
Setting shebang so will run as node instead of shell.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict';
 // Modules
 require('chili-js');


### PR DESCRIPTION
Resolves Rawnly/splash-cli#6.