### PR TITLE
Fixing beta markers indentation.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -56,8 +56,8 @@ const cli = new Meow(`
     ${chalk.yellow('-h --help')}                          ${chalk.gray('# Display this message')}
     ${chalk.yellow('-v --version')}                       ${chalk.gray('# Display splash version')}
 
-    ${chalk.yellow('-a --auth')} 						${chalk.gray('~ Beta ~')}
-    ${chalk.yellow('--force')} 							${chalk.gray('~ Beta ~')}
+    ${chalk.yellow('-a --auth')}			${chalk.gray('~ Beta ~')}
+    ${chalk.yellow('--force')}				${chalk.gray('~ Beta ~')}
 
     ${chalk.blue('Picker parameters')}
 


### PR DESCRIPTION
When the user enters `splash -h` the beta markers for `-a --auth` and `--force` are unaligned, and it's ever-so-slightly annoying.

<!-- Thanks for this pull-request! -->
<!-- It's important keep splash-cli updated -->
<!-- Please before submit check a few things -->

- [x] I've read [roadmap file](docs/roadmap.md).
- [x] I've runned all tests and they are ok.
- [x] While writing i've keep the [xo](https://github.com/sindresorhus/xo) code style.

# Features of this pull

Literally just changes how the CLI help is displayed.

<!-- Thanks again! -->
